### PR TITLE
Fix build errors

### DIFF
--- a/oc3_city.hpp
+++ b/oc3_city.hpp
@@ -27,6 +27,7 @@
 #include "oc3_predefinitions.hpp"
 #include "oc3_referencecounted.hpp"
 #include "oc3_cityservice.hpp"
+#include "oc3_tile.hpp"
 
 class TilePos;
 class DateTime;

--- a/oc3_goodstore.cpp
+++ b/oc3_goodstore.cpp
@@ -202,7 +202,7 @@ void GoodStore::save( VariantMap& stream) const
   {
     VariantList vm_stocksave;
     itRes->second.save( vm_stocksave );
-    vm_storeReservations.push_back( itRes->first );
+    vm_storeReservations.push_back( (int)itRes->first );
     vm_storeReservations.push_back( vm_stocksave );
   }
   stream[ "storeReservations" ] = vm_storeReservations;
@@ -213,7 +213,7 @@ void GoodStore::save( VariantMap& stream) const
   {
     VariantList vm_stockrtvsave;
     itRes->second.save( vm_stockrtvsave );
-    vm_retrieveReservations.push_back( itRes->first );
+    vm_retrieveReservations.push_back( (int)itRes->first );
     vm_retrieveReservations.push_back( vm_stockrtvsave );
   }
   stream[ "retrieveReservation" ] = vm_retrieveReservations;

--- a/oc3_groupbox.cpp
+++ b/oc3_groupbox.cpp
@@ -55,7 +55,8 @@ void GroupBox::draw( GfxEngine& painter )
     if (!isVisible())
         return;
 
-    painter.drawPicture( *_d->texture, getScreenLeft(), getScreenTop(), &Widget::getAbsoluteClippingRect() );
+    Rect clippingRect = Widget::getAbsoluteClippingRect();
+    painter.drawPicture( *_d->texture, getScreenLeft(), getScreenTop(), &clippingRect );
 
     Widget::draw( painter );
 }

--- a/oc3_gui_info_box.cpp
+++ b/oc3_gui_info_box.cpp
@@ -296,7 +296,7 @@ void InfoBoxHouse::drawGood(const GoodType &goodType, const int col, const int r
   int qty = _ed->house->getGoodStore().getCurrentQty(goodType);
 
   // pictures of goods
-  Picture& pic = GoodHelper::getPicture( goodType );
+  const Picture& pic = GoodHelper::getPicture( goodType );
   _d->bgPicture->draw(pic, 31 + 100 * col, startY + 2 + 30 * row);
 
   std::string text = StringHelper::format( 0xff, "%d", qty);
@@ -327,14 +327,14 @@ void GuiInfoFactory::paint()
 
   if( _building->getOutGoodType() != G_NONE )
   {
-    Picture &pic = GoodHelper::getPicture( _building->getOutGoodType() );
+    const Picture &pic = GoodHelper::getPicture( _building->getOutGoodType() );
     _d->bgPicture->draw(pic, 10, 10);
   }
 
   // paint picture of in good
   if( _building->getInGood()._goodType != G_NONE )
   {
-    Picture &pic = GoodHelper::getPicture( _building->getInGood()._goodType );
+    const Picture &pic = GoodHelper::getPicture( _building->getInGood()._goodType );
     _d->bgPicture->draw(pic, 32, _paintY+2);
     int amount = _building->getInGood()._currentQty / 100;
     std::string goodName = GoodHelper::getName( _building->getInGood()._goodType );
@@ -497,7 +497,7 @@ void GuiInfoGranary::drawGood(const GoodType &goodType, int col, int& paintY)
   int qty = _gd->building->getGoodStore().getCurrentQty(goodType);
 
   // pictures of goods
-  Picture& pic = GoodHelper::getPicture( goodType );
+  const Picture& pic = GoodHelper::getPicture( goodType );
   _d->bgPicture->draw(pic, (col == 0 ? 31 : 250), paintY);
 
   std::string outText = StringHelper::format( 0xff, "%d %s", qty, goodName.c_str() );
@@ -601,7 +601,7 @@ void InfoBoxWarehouse::drawGood(const GoodType &goodType, int col, int& paintY)
   int qty = _wd->building->getGoodStore().getCurrentQty(goodType);
 
   // pictures of goods
-  Picture& pic = GoodHelper::getPicture( goodType );
+  const Picture& pic = GoodHelper::getPicture( goodType );
   _d->bgPicture->draw(pic, col * 150 + 15, paintY);
 
   std::string outText = StringHelper::format( 0xff, "%d %s", qty, goodName.c_str() );
@@ -745,7 +745,7 @@ void GuiInfoMarket::drawGood(const GoodType &goodType, int index, int paintY )
   std::string goodName = GoodHelper::getName( goodType );
 
   // pictures of goods
-  Picture& pic = GoodHelper::getPicture( goodType );
+  const Picture& pic = GoodHelper::getPicture( goodType );
   Point pos( index * offset + startOffset, paintY );
   _d->bgPicture->draw( pic, pos.getX(), pos.getY() );
 
@@ -899,7 +899,7 @@ InfoBoxRawMaterial::InfoBoxRawMaterial( Widget* parent, const Tile& tile )
 
   if( _fd->rawmb->getOutGoodType() != G_NONE )
   {
-    Picture &pic = GoodHelper::getPicture( _fd->rawmb->getOutGoodType() );
+    const Picture &pic = GoodHelper::getPicture( _fd->rawmb->getOutGoodType() );
     _d->bgPicture->draw(pic, 10, 10);
   }
 
@@ -963,7 +963,7 @@ InfoBoxRawMaterial::InfoBoxRawMaterial( Widget* parent, const Tile& tile )
   setTitle( name );
 
    // pictures of goods
-  Picture& goodIcon = GoodHelper::getPicture( goodType );
+  const Picture& goodIcon = GoodHelper::getPicture( goodType );
   _d->bgPicture->draw( goodIcon, 16, 16 );
 
   _fd->updateAboutText();

--- a/oc3_label.cpp
+++ b/oc3_label.cpp
@@ -175,7 +175,8 @@ void Label::draw( GfxEngine& painter )
   // draw background
   if( _d->picture )
   {
-    painter.drawPicture( *_d->picture, frameRect.getLeft(), frameRect.getTop(), &getAbsoluteClippingRect() );
+    Rect clippingRect = getAbsoluteClippingRect();
+    painter.drawPicture( *_d->picture, frameRect.getLeft(), frameRect.getTop(), &clippingRect );
   }
 
   Widget::draw( painter );

--- a/oc3_picture_info_bank.hpp
+++ b/oc3_picture_info_bank.hpp
@@ -1,4 +1,4 @@
-﻿// This file is part of openCaesar3.
+// This file is part of openCaesar3.
 //
 // openCaesar3 is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/oc3_pushbutton.cpp
+++ b/oc3_pushbutton.cpp
@@ -369,7 +369,8 @@ void PushButton::draw( GfxEngine& painter )
 	  const ButtonState& state = _d->buttonStates[ _d->currentButtonState ];
     if( state.texture )
     {
-      painter.drawPicture( *state.texture, getScreenLeft(), getScreenTop(), &getAbsoluteClippingRect() );
+      Rect clippingRect = getAbsoluteClippingRect();
+      painter.drawPicture( *state.texture, getScreenLeft(), getScreenTop(), &clippingRect );
 
 //             if( isEnabled() &&
 //                 ( hoverImageOpacity <= 0xff ) &&

--- a/oc3_rectangle.hpp
+++ b/oc3_rectangle.hpp
@@ -312,7 +312,7 @@ class Rect : public RectT<int>
 {
 public:
 
-  Rect() : RectT( 0, 0, 0, 0 ) {}
+  Rect() : RectT<int>( 0, 0, 0, 0 ) {}
   //! Constructor with upper left corner and dimension
   Rect(const Point& pos, const Size& size)
     : RectT<int>( pos, Point( pos.getX() + size.getWidth(), pos.getY() + size.getHeight() ) ) {}
@@ -337,7 +337,7 @@ public:
   }
 
   Rect( const Point& p1, const Point& p2 ) 
-    : RectT( p1, p2 ) {}
+    : RectT<int>( p1, p2 ) {}
 
   RectF toRectF() const;
 };
@@ -345,7 +345,7 @@ public:
 class RectF : public RectT<float>
 {
 public:
-  RectF() : RectT( 0, 0, 0, 0 ) {}
+  RectF() : RectT<float>( 0, 0, 0, 0 ) {}
 
   RectF( float x1, float y1, float x2, float y2 )
     : RectT<float>( x1, y1, x2, y2 ) {}

--- a/oc3_screen_wait.hpp
+++ b/oc3_screen_wait.hpp
@@ -1,4 +1,4 @@
-﻿#ifndef SCREEN_WAIT_HPP
+#ifndef SCREEN_WAIT_HPP
 #define SCREEN_WAIT_HPP
 
 #include "oc3_screen.hpp"


### PR DESCRIPTION
Fix build errors generated by gcc 7 and clang on FreeBSD/amd64

98cf06e should be checked for whether selected type (int) is long enough (long long may be required instead).
