### PR TITLE
Use current directory as fallback application directory

### DIFF
--- a/oc3_filepath.cpp
+++ b/oc3_filepath.cpp
@@ -609,7 +609,7 @@ FileDir FileDir::getApplicationDir()
   return FilePath(dirname(exe_path));
 #endif
 
-  return FilePath( "" );
+  return FilePath( "." );
 }
 
 } //end namespace io


### PR DESCRIPTION
With this more sane paths are generated, e.g. ./resources/foo instead
of /resources/foo
