### PR TITLE
Fix crash on accessing past-the-end of a vector

### DIFF
--- a/oc3_animation_bank.cpp
+++ b/oc3_animation_bank.cpp
@@ -90,7 +90,7 @@ void AnimationBank::Impl::loadCarts()
 
 void AnimationBank::Impl::loadWalkers()
 {
-  animations.resize(30);  // number of walker types
+  animations.resize(WG_MAX);  // number of walker types
 
   animations[WG_POOR] =     loadAnimation( "citizen01", 1, 12 );
   animations[WG_BATH] =     loadAnimation( "citizen01", 105, 12);


### PR DESCRIPTION
WG_ANIMAL_SHEEP_WALK == 30, so it won't fit to 30-element vector, so the game crashes. Use safer enum to specify vector size.
